### PR TITLE
Fix SQLite timeouts and modernc driver

### DIFF
--- a/models/comment.go
+++ b/models/comment.go
@@ -1,38 +1,52 @@
 package models
 
-
+import (
+	"context"
+	"log"
+)
 
 type Comment struct {
-	ID        int64
-	PostID    int64
-	AuthorID  int64
-	Author    string
-	Content   string
-	CreatedAt string
-	LikeCount int
+	ID           int64
+	PostID       int64
+	AuthorID     int64
+	Author       string
+	Content      string
+	CreatedAt    string
+	LikeCount    int
 	DislikeCount int
 }
 
-func CreateComment(postID, authorID int64, content string) (int64, error) {
-	res, err := DB.Exec(`INSERT INTO comments(post_id, author_id, content, created_at) VALUES(?,?,?,datetime('now'))`,
-		postID, authorID, content)
-	if err != nil { return 0, err }
-	return res.LastInsertId()
+func CreateComment(postID, authorID int64, content string) (id int64, err error) {
+	log.Printf("models.CreateComment start")
+	defer func() { log.Printf("models.CreateComment end: id=%d err=%v", id, err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	res, err := DB.ExecContext(ctx, `INSERT INTO comments(post_id, author_id, content, created_at) VALUES(?,?,?,datetime('now'))`, postID, authorID, content)
+	if err != nil {
+		return 0, err
+	}
+	id, err = res.LastInsertId()
+	return id, err
 }
 
-func ListComments(postID int64) ([]Comment, error) {
-	rows, err := DB.Query(`
-	SELECT c.id, c.post_id, c.author_id, u.username, c.content, c.created_at,
-		COALESCE(SUM(CASE WHEN l.value=1 THEN 1 ELSE 0 END),0),
-		COALESCE(SUM(CASE WHEN l.value=-1 THEN 1 ELSE 0 END),0)
-	FROM comments c JOIN users u ON u.id=c.author_id
-	LEFT JOIN likes l ON l.target_type='comment' AND l.target_id=c.id
-	WHERE c.post_id=?
-	GROUP BY c.id ORDER BY c.id ASC`, postID)
-	if err != nil { return nil, err }
+func ListComments(postID int64) (out []Comment, err error) {
+	log.Printf("models.ListComments start postID=%d", postID)
+	defer func() { log.Printf("models.ListComments end: n=%d err=%v", len(out), err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	rows, err := DB.QueryContext(ctx, `
+        SELECT c.id, c.post_id, c.author_id, u.username, c.content, c.created_at,
+                COALESCE(SUM(CASE WHEN l.value=1 THEN 1 ELSE 0 END),0),
+                COALESCE(SUM(CASE WHEN l.value=-1 THEN 1 ELSE 0 END),0)
+        FROM comments c JOIN users u ON u.id=c.author_id
+        LEFT JOIN likes l ON l.target_type='comment' AND l.target_id=c.id
+        WHERE c.post_id=?
+        GROUP BY c.id ORDER BY c.id ASC`, postID)
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
 
-	var out []Comment
 	for rows.Next() {
 		var c Comment
 		if err := rows.Scan(&c.ID, &c.PostID, &c.AuthorID, &c.Author, &c.Content, &c.CreatedAt, &c.LikeCount, &c.DislikeCount); err != nil {

--- a/models/like.go
+++ b/models/like.go
@@ -1,34 +1,41 @@
 package models
 
-import "database/sql"
+import (
+	"context"
+	"database/sql"
+	"log"
+)
 
 // likes table is used for posts & comments via target_type + target_id
 // value = 1 (like), -1 (dislike)
-func SetReaction(userID int64, targetType string, targetID int64, value int) error {
-	if targetType != "post" && targetType != "comment" { return ErrNotFound }
-	if value != 1 && value != -1 { return ErrNotFound }
-	// If same reaction exists -> remove (toggle). If opposite exists -> update.
+func SetReaction(userID int64, targetType string, targetID int64, value int) (err error) {
+	log.Printf("models.SetReaction start userID=%d targetType=%s targetID=%d value=%d", userID, targetType, targetID, value)
+	defer func() { log.Printf("models.SetReaction end err=%v", err) }()
+	if targetType != "post" && targetType != "comment" {
+		return ErrNotFound
+	}
+	if value != 1 && value != -1 {
+		return ErrNotFound
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
 	var existing int
 	var curVal sql.NullInt64
-	row := DB.QueryRow(`SELECT value FROM likes WHERE user_id=? AND target_type=? AND target_id=?`,
-		userID, targetType, targetID)
-	if err := row.Scan(&curVal); err != nil && err != sql.ErrNoRows {
+	row := DB.QueryRowContext(ctx, `SELECT value FROM likes WHERE user_id=? AND target_type=? AND target_id=?`, userID, targetType, targetID)
+	if err = row.Scan(&curVal); err != nil && err != sql.ErrNoRows {
 		return err
 	}
 	if curVal.Valid {
 		existing = int(curVal.Int64)
 	}
 	if existing == value {
-		_, err := DB.Exec(`DELETE FROM likes WHERE user_id=? AND target_type=? AND target_id=?`,
-			userID, targetType, targetID)
+		_, err = DB.ExecContext(ctx, `DELETE FROM likes WHERE user_id=? AND target_type=? AND target_id=?`, userID, targetType, targetID)
 		return err
 	}
 	if existing == -value {
-		_, err := DB.Exec(`UPDATE likes SET value=? WHERE user_id=? AND target_type=? AND target_id=?`,
-			value, userID, targetType, targetID)
+		_, err = DB.ExecContext(ctx, `UPDATE likes SET value=? WHERE user_id=? AND target_type=? AND target_id=?`, value, userID, targetType, targetID)
 		return err
 	}
-	_, err := DB.Exec(`INSERT INTO likes(user_id, target_type, target_id, value, created_at) VALUES(?,?,?,?,datetime('now'))`,
-		userID, targetType, targetID, value)
+	_, err = DB.ExecContext(ctx, `INSERT INTO likes(user_id, target_type, target_id, value, created_at) VALUES(?,?,?,?,datetime('now'))`, userID, targetType, targetID, value)
 	return err
 }

--- a/models/post.go
+++ b/models/post.go
@@ -1,9 +1,10 @@
-
 package models
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"log"
 	"strings"
 )
 
@@ -19,47 +20,66 @@ type Post struct {
 	Categories   []string
 }
 
-func CreatePost(authorID int64, title, content string, categories []string) (int64, error) {
+func CreatePost(authorID int64, title, content string, categories []string) (pid int64, err error) {
+	log.Printf("models.CreatePost start")
+	defer func() { log.Printf("models.CreatePost end: pid=%d err=%v", pid, err) }()
 	if title == "" || content == "" {
 		return 0, errors.New("missing fields")
 	}
-	tx, err := DB.Begin()
-	if err != nil { return 0, err }
-	defer func(){ if err != nil { _ = tx.Rollback() } }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	tx, err := DB.BeginTx(ctx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
 
-	res, err := tx.Exec(`INSERT INTO posts(title, content, author_id, created_at) VALUES(?,?,?,datetime('now'))`,
-		title, content, authorID)
-	if err != nil { return 0, err }
-	pid, _ := res.LastInsertId()
+	res, err := tx.ExecContext(ctx, `INSERT INTO posts(title, content, author_id, created_at) VALUES(?,?,?,datetime('now'))`, title, content, authorID)
+	if err != nil {
+		return 0, err
+	}
+	pid, _ = res.LastInsertId()
 
 	for _, c := range categories {
 		c = strings.TrimSpace(c)
-		if c == "" { continue }
+		if c == "" {
+			continue
+		}
 		var cid int64
-		err = tx.QueryRow(`SELECT id FROM categories WHERE name=?`, c).Scan(&cid)
+		err = tx.QueryRowContext(ctx, `SELECT id FROM categories WHERE name=?`, c).Scan(&cid)
 		if err == sql.ErrNoRows {
-			res2, err2 := tx.Exec(`INSERT INTO categories(name) VALUES(?)`, c)
-			if err2 != nil { return 0, err2 }
+			res2, err2 := tx.ExecContext(ctx, `INSERT INTO categories(name) VALUES(?)`, c)
+			if err2 != nil {
+				return 0, err2
+			}
 			cid, _ = res2.LastInsertId()
 		} else if err != nil {
 			return 0, err
 		}
-		if _, err = tx.Exec(`INSERT OR IGNORE INTO post_categories(post_id, category_id) VALUES(?,?)`, pid, cid); err != nil {
+		if _, err = tx.ExecContext(ctx, `INSERT OR IGNORE INTO post_categories(post_id, category_id) VALUES(?,?)`, pid, cid); err != nil {
 			return 0, err
 		}
 	}
-	if err = tx.Commit(); err != nil { return 0, err }
+	if err = tx.Commit(); err != nil {
+		return 0, err
+	}
 	return pid, nil
 }
 
 type PostFilter struct {
-	Categories     []string
-	MineUserID     int64
-	LikedByUserID  int64
+	Categories    []string
+	MineUserID    int64
+	LikedByUserID int64
 }
 
 // ANY-of selected categories
-func ListPosts(f PostFilter) ([]Post, error) {
+func ListPosts(f PostFilter) (out []Post, err error) {
+	log.Printf("models.ListPosts start")
+	defer func() { log.Printf("models.ListPosts end: posts=%d err=%v", len(out), err) }()
 	q := `
 SELECT p.id, p.title, p.content, p.author_id, u.username, p.created_at,
        COALESCE(SUM(CASE WHEN l.value=1 THEN 1 ELSE 0 END),0) as likes,
@@ -71,11 +91,13 @@ LEFT JOIN likes l ON l.target_type='post' AND l.target_id=p.id
 LEFT JOIN post_categories pc ON pc.post_id = p.id
 LEFT JOIN categories c ON c.id = pc.category_id
 `
-	args := []interface{}{}
+	args := []any{}
 	if len(f.Categories) > 0 {
 		q += " WHERE p.id IN (SELECT pc.post_id FROM post_categories pc JOIN categories c ON c.id=pc.category_id WHERE c.name IN ("
 		for i := range f.Categories {
-			if i > 0 { q += "," }
+			if i > 0 {
+				q += ","
+			}
 			q += "?"
 			args = append(args, f.Categories[i])
 		}
@@ -94,11 +116,14 @@ LEFT JOIN categories c ON c.id = pc.category_id
 
 	q += " GROUP BY p.id ORDER BY p.id DESC LIMIT 200"
 
-	rows, err := DB.Query(q, args...)
-	if err != nil { return nil, err }
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	rows, err := DB.QueryContext(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
 
-	var out []Post
 	for rows.Next() {
 		var p Post
 		var cats sql.NullString
@@ -113,8 +138,12 @@ LEFT JOIN categories c ON c.id = pc.category_id
 	return out, nil
 }
 
-func GetPost(id int64) (*Post, error) {
-	row := DB.QueryRow(`
+func GetPost(id int64) (post *Post, err error) {
+	log.Printf("models.GetPost start id=%d", id)
+	defer func() { log.Printf("models.GetPost end id=%d err=%v", id, err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	row := DB.QueryRowContext(ctx, `
 SELECT p.id, p.title, p.content, p.author_id, u.username, p.created_at,
        COALESCE(SUM(CASE WHEN l.value=1 THEN 1 ELSE 0 END),0),
        COALESCE(SUM(CASE WHEN l.value=-1 THEN 1 ELSE 0 END),0)
@@ -122,24 +151,35 @@ FROM posts p JOIN users u ON u.id=p.author_id
 LEFT JOIN likes l ON l.target_type='post' AND l.target_id=p.id
 WHERE p.id=?`, id)
 	var p Post
-	if err := row.Scan(&p.ID, &p.Title, &p.Content, &p.AuthorID, &p.Author, &p.CreatedAt, &p.LikeCount, &p.DislikeCount); err != nil {
-		if err == sql.ErrNoRows { return nil, ErrNotFound }
+	if err = row.Scan(&p.ID, &p.Title, &p.Content, &p.AuthorID, &p.Author, &p.CreatedAt, &p.LikeCount, &p.DislikeCount); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
-	crows, err := DB.Query(`SELECT c.name FROM categories c JOIN post_categories pc ON pc.category_id=c.id WHERE pc.post_id=?`, p.ID)
+	crows, err := DB.QueryContext(ctx, `SELECT c.name FROM categories c JOIN post_categories pc ON pc.category_id=c.id WHERE pc.post_id=?`, p.ID)
 	if err == nil {
-		for crows.Next() { var name string; _ = crows.Scan(&name); p.Categories = append(p.Categories, name) }
+		for crows.Next() {
+			var name string
+			_ = crows.Scan(&name)
+			p.Categories = append(p.Categories, name)
+		}
 		crows.Close()
 	}
 	return &p, nil
 }
 
 // ListAllCategories returns all category names
-func ListAllCategories() ([]string, error) {
-	rows, err := DB.Query(`SELECT name FROM categories ORDER BY name ASC`)
-	if err != nil { return nil, err }
+func ListAllCategories() (out []string, err error) {
+	log.Printf("models.ListAllCategories start")
+	defer func() { log.Printf("models.ListAllCategories end: n=%d err=%v", len(out), err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	rows, err := DB.QueryContext(ctx, `SELECT name FROM categories ORDER BY name ASC`)
+	if err != nil {
+		return nil, err
+	}
 	defer rows.Close()
-	var out []string
 	for rows.Next() {
 		var n string
 		if err := rows.Scan(&n); err != nil {

--- a/models/session.go
+++ b/models/session.go
@@ -1,7 +1,9 @@
 package models
 
 import (
+	"context"
 	"errors"
+	"log"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,28 +19,37 @@ type Session struct {
 const SessionTTL = 60 * time.Minute
 
 // CreateSingleSession deletes any existing sessions for user, then creates a new one.
-func CreateSingleSession(userID int64) (*Session, error) {
-	if _, err := DB.Exec(`DELETE FROM sessions WHERE user_id=?`, userID); err != nil {
+func CreateSingleSession(userID int64) (s *Session, err error) {
+	log.Printf("models.CreateSingleSession start userID=%d", userID)
+	defer func() { log.Printf("models.CreateSingleSession end err=%v", err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	if _, err = DB.ExecContext(ctx, `DELETE FROM sessions WHERE user_id=?`, userID); err != nil {
 		return nil, err
 	}
 	sid := uuid.New().String()
 	exp := time.Now().Add(SessionTTL).UTC()
-	_, err := DB.Exec(`INSERT INTO sessions(id, user_id, expires_at, created_at) VALUES(?,?,?,datetime('now'))`,
-		sid, userID, exp.Format(time.RFC3339))
-	if err != nil { return nil, err }
+	_, err = DB.ExecContext(ctx, `INSERT INTO sessions(id, user_id, expires_at, created_at) VALUES(?,?,?,datetime('now'))`, sid, userID, exp.Format(time.RFC3339))
+	if err != nil {
+		return nil, err
+	}
 	return &Session{ID: sid, UserID: userID, ExpiresAt: exp, CreatedAt: time.Now().UTC()}, nil
 }
 
-func SessionFromID(id string) (*Session, error) {
-	row := DB.QueryRow(`SELECT id, user_id, expires_at, created_at FROM sessions WHERE id=?`, id)
-	s := &Session{}
+func SessionFromID(id string) (s *Session, err error) {
+	log.Printf("models.SessionFromID start id=%s", id)
+	defer func() { log.Printf("models.SessionFromID end err=%v", err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	row := DB.QueryRowContext(ctx, `SELECT id, user_id, expires_at, created_at FROM sessions WHERE id=?`, id)
+	s = &Session{}
 	var expStr, cStr string
-	if err := row.Scan(&s.ID, &s.UserID, &expStr, &cStr); err != nil {
+	if err = row.Scan(&s.ID, &s.UserID, &expStr, &cStr); err != nil {
 		return nil, ErrNotFound
 	}
-	var err error
-	s.ExpiresAt, err = time.Parse(time.RFC3339, expStr)
-	if err != nil { return nil, err }
+	if s.ExpiresAt, err = time.Parse(time.RFC3339, expStr); err != nil {
+		return nil, err
+	}
 	s.CreatedAt, _ = time.Parse(time.RFC3339, cStr)
 	if time.Now().After(s.ExpiresAt) {
 		_ = DeleteSession(id)
@@ -47,7 +58,11 @@ func SessionFromID(id string) (*Session, error) {
 	return s, nil
 }
 
-func DeleteSession(id string) error {
-	_, err := DB.Exec(`DELETE FROM sessions WHERE id=?`, id)
+func DeleteSession(id string) (err error) {
+	log.Printf("models.DeleteSession start id=%s", id)
+	defer func() { log.Printf("models.DeleteSession end err=%v", err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	_, err = DB.ExecContext(ctx, `DELETE FROM sessions WHERE id=?`, id)
 	return err
 }

--- a/models/user.go
+++ b/models/user.go
@@ -1,8 +1,10 @@
 package models
 
 import (
+	"context"
 	"database/sql"
 	"errors"
+	"log"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -16,53 +18,73 @@ type User struct {
 }
 
 // CreateUser inserts a new user (email + username unique). Password will be hashed.
-func CreateUser(email, username, password string) (*User, error) {
+func CreateUser(email, username, password string) (u *User, err error) {
+	log.Printf("models.CreateUser start email=%s", email)
+	defer func() { log.Printf("models.CreateUser end err=%v", err) }()
 	if email == "" || username == "" || password == "" {
 		return nil, errors.New("missing fields")
 	}
-	// check duplicates
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
 	var exists int
-	row := DB.QueryRow(`SELECT 1 FROM users WHERE email=? OR username=? LIMIT 1`, email, username)
-	if err := row.Scan(&exists); err != nil && err != sql.ErrNoRows {
+	row := DB.QueryRowContext(ctx, `SELECT 1 FROM users WHERE email=? OR username=? LIMIT 1`, email, username)
+	if err = row.Scan(&exists); err != nil && err != sql.ErrNoRows {
 		return nil, err
 	}
 	if exists == 1 {
 		return nil, errors.New("email or username taken")
 	}
 	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
-	if err != nil { return nil, err }
-
-	res, err := DB.Exec(`INSERT INTO users(email, username, password_hash, created_at) VALUES(?,?,?,datetime('now'))`,
-		email, username, string(hash))
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
+	res, err := DB.ExecContext(ctx, `INSERT INTO users(email, username, password_hash, created_at) VALUES(?,?,?,datetime('now'))`, email, username, string(hash))
+	if err != nil {
+		return nil, err
+	}
 	id, _ := res.LastInsertId()
 	return &User{ID: id, Email: email, Username: username, PasswordHash: string(hash)}, nil
 }
 
-func GetUserByID(id int64) (*User, error) {
-	row := DB.QueryRow(`SELECT id, email, username, password_hash, created_at FROM users WHERE id=?`, id)
-	u := &User{}
-	if err := row.Scan(&u.ID, &u.Email, &u.Username, &u.PasswordHash, &u.CreatedAt); err != nil {
-		if err == sql.ErrNoRows { return nil, ErrNotFound }
+func GetUserByID(id int64) (u *User, err error) {
+	log.Printf("models.GetUserByID start id=%d", id)
+	defer func() { log.Printf("models.GetUserByID end err=%v", err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	row := DB.QueryRowContext(ctx, `SELECT id, email, username, password_hash, created_at FROM users WHERE id=?`, id)
+	u = &User{}
+	if err = row.Scan(&u.ID, &u.Email, &u.Username, &u.PasswordHash, &u.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	return u, nil
 }
 
-func FindUserByLogin(login string) (*User, error) {
-	row := DB.QueryRow(`SELECT id, email, username, password_hash, created_at
-		FROM users WHERE email=? OR username=?`, login, login)
-	u := &User{}
-	if err := row.Scan(&u.ID, &u.Email, &u.Username, &u.PasswordHash, &u.CreatedAt); err != nil {
-		if err == sql.ErrNoRows { return nil, ErrNotFound }
+func FindUserByLogin(login string) (u *User, err error) {
+	log.Printf("models.FindUserByLogin start login=%s", login)
+	defer func() { log.Printf("models.FindUserByLogin end err=%v", err) }()
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+	row := DB.QueryRowContext(ctx, `SELECT id, email, username, password_hash, created_at FROM users WHERE email=? OR username=?`, login, login)
+	u = &User{}
+	if err = row.Scan(&u.ID, &u.Email, &u.Username, &u.PasswordHash, &u.CreatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrNotFound
+		}
 		return nil, err
 	}
 	return u, nil
 }
 
-func Authenticate(login, password string) (*User, error) {
-	u, err := FindUserByLogin(login)
-	if err != nil { return nil, err }
+func Authenticate(login, password string) (u *User, err error) {
+	log.Printf("models.Authenticate start login=%s", login)
+	defer func() { log.Printf("models.Authenticate end err=%v", err) }()
+	u, err = FindUserByLogin(login)
+	if err != nil {
+		return nil, err
+	}
 	if bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte(password)) != nil {
 		return nil, errors.New("invalid credentials")
 	}


### PR DESCRIPTION
## Summary
- switch to modernc SQLite driver with WAL, busy timeout and query timeouts
- wrap all database calls with context deadlines and add logging
- buffer error templates to avoid blank responses and log handler lifecycle

## Testing
- `go mod tidy` *(fails: unrecognized import path, network access forbidden)*
- `go run main.go` *(fails: unrecognized import path, network access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acf610ea148333a1365463da7b9f51